### PR TITLE
Add appointment scheduling module with reminders

### DIFF
--- a/backend/Routes/turnos.js
+++ b/backend/Routes/turnos.js
@@ -1,0 +1,246 @@
+const express = require('express');
+const router = express.Router();
+const Turno = require('../models/Turno');
+const Paciente = require('../models/Paciente');
+const { protect } = require('../middleware/authMiddleware');
+
+const calcularRecordatorio = (fecha, horasAntes) => {
+  if (!fecha || horasAntes === undefined || horasAntes === null) {
+    return null;
+  }
+
+  const horas = Number(horasAntes);
+  if (Number.isNaN(horas)) {
+    return null;
+  }
+
+  const fechaTurno = new Date(fecha);
+  if (Number.isNaN(fechaTurno.getTime())) {
+    return null;
+  }
+
+  return new Date(fechaTurno.getTime() - horas * 60 * 60 * 1000);
+};
+
+const sanitizarRecordatorio = (recordatorioHorasAntes) => {
+  if (recordatorioHorasAntes === '' || recordatorioHorasAntes === null) {
+    return undefined;
+  }
+  if (recordatorioHorasAntes === undefined) {
+    return undefined;
+  }
+
+  const numero = Number(recordatorioHorasAntes);
+  return Number.isNaN(numero) ? undefined : numero;
+};
+
+// Crear un nuevo turno
+router.post('/', protect, async (req, res) => {
+  try {
+    const {
+      paciente,
+      fecha,
+      duracionMinutos,
+      estado,
+      notas,
+      titulo,
+      recordatorioHorasAntes,
+    } = req.body;
+
+    const pacienteAsociado = await Paciente.findOne({
+      _id: paciente,
+      user: req.user._id,
+    });
+
+    if (!pacienteAsociado) {
+      return res.status(404).json({ error: 'Paciente no encontrado o no autorizado' });
+    }
+
+    const recordatorioSanitizado = sanitizarRecordatorio(recordatorioHorasAntes);
+
+    const nuevoTurno = new Turno({
+      user: req.user._id,
+      paciente,
+      fecha,
+      duracionMinutos,
+      estado,
+      notas,
+      titulo,
+      recordatorioHorasAntes: recordatorioSanitizado,
+      recordatorioProgramadoPara: calcularRecordatorio(fecha, recordatorioSanitizado),
+      recordatorioEnviado: false,
+    });
+
+    await nuevoTurno.save();
+    const turnoConPaciente = await nuevoTurno.populate('paciente', 'nombre apellido dni');
+    res.status(201).json(turnoConPaciente);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+// Obtener todos los turnos del usuario autenticado
+router.get('/', protect, async (req, res) => {
+  try {
+    const { estado, desde, hasta } = req.query;
+    const filtro = { user: req.user._id };
+
+    if (estado) {
+      filtro.estado = estado;
+    }
+
+    if (desde || hasta) {
+      filtro.fecha = {};
+      if (desde) {
+        filtro.fecha.$gte = new Date(desde);
+      }
+      if (hasta) {
+        filtro.fecha.$lte = new Date(hasta);
+      }
+    }
+
+    const turnos = await Turno.find(filtro)
+      .sort({ fecha: 1 })
+      .populate('paciente', 'nombre apellido dni');
+
+    res.json(turnos);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Obtener un turno por ID
+router.get('/:id', protect, async (req, res) => {
+  try {
+    const turno = await Turno.findOne({
+      _id: req.params.id,
+      user: req.user._id,
+    }).populate('paciente', 'nombre apellido dni');
+
+    if (!turno) {
+      return res.status(404).json({ error: 'Turno no encontrado o no autorizado' });
+    }
+
+    res.json(turno);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Actualizar un turno
+router.put('/:id', protect, async (req, res) => {
+  try {
+    const {
+      paciente,
+      fecha,
+      duracionMinutos,
+      estado,
+      notas,
+      titulo,
+      recordatorioHorasAntes,
+      recordatorioEnviado,
+    } = req.body;
+
+    const turno = await Turno.findOne({
+      _id: req.params.id,
+      user: req.user._id,
+    });
+
+    if (!turno) {
+      return res.status(404).json({ error: 'Turno no encontrado o no autorizado' });
+    }
+
+    if (paciente && paciente.toString() !== turno.paciente.toString()) {
+      const pacienteAsociado = await Paciente.findOne({
+        _id: paciente,
+        user: req.user._id,
+      });
+
+      if (!pacienteAsociado) {
+        return res.status(404).json({ error: 'Paciente no encontrado o no autorizado' });
+      }
+
+      turno.paciente = paciente;
+    }
+
+    if (fecha) {
+      turno.fecha = fecha;
+    }
+
+    if (duracionMinutos !== undefined) {
+      turno.duracionMinutos = duracionMinutos;
+    }
+
+    if (estado) {
+      turno.estado = estado;
+    }
+
+    if (notas !== undefined) {
+      turno.notas = notas;
+    }
+
+    if (titulo !== undefined) {
+      turno.titulo = titulo;
+    }
+
+    const recordatorioSanitizado = sanitizarRecordatorio(recordatorioHorasAntes);
+    if (recordatorioHorasAntes !== undefined) {
+      turno.recordatorioHorasAntes = recordatorioSanitizado;
+    }
+
+    if (recordatorioEnviado !== undefined) {
+      turno.recordatorioEnviado = recordatorioEnviado;
+    }
+
+    turno.recordatorioProgramadoPara = calcularRecordatorio(
+      turno.fecha,
+      turno.recordatorioHorasAntes
+    );
+
+    await turno.save();
+    const turnoActualizado = await turno.populate('paciente', 'nombre apellido dni');
+    res.json(turnoActualizado);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+// Actualizar el estado del recordatorio
+router.patch('/:id/recordatorio', protect, async (req, res) => {
+  try {
+    const { recordatorioEnviado } = req.body;
+    const turnoActualizado = await Turno.findOneAndUpdate(
+      { _id: req.params.id, user: req.user._id },
+      { recordatorioEnviado: !!recordatorioEnviado },
+      { new: true }
+    ).populate('paciente', 'nombre apellido dni');
+
+    if (!turnoActualizado) {
+      return res.status(404).json({ error: 'Turno no encontrado o no autorizado' });
+    }
+
+    res.json(turnoActualizado);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+// Eliminar un turno
+router.delete('/:id', protect, async (req, res) => {
+  try {
+    const turnoEliminado = await Turno.findOneAndDelete({
+      _id: req.params.id,
+      user: req.user._id,
+    });
+
+    if (!turnoEliminado) {
+      return res.status(404).json({ error: 'Turno no encontrado o no autorizado' });
+    }
+
+    res.json({ message: 'Turno eliminado correctamente' });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,7 @@ const dotenv = require('dotenv');
 const pacientesRoutes = require('./Routes/pacientes');
 const obrasSocialesRoutes = require('./Routes/obrasSociales');
 const facturasRoutes = require('./Routes/facturas');
+const turnosRoutes = require('./Routes/turnos');
 const userRoutes = require('./Routes/userRoutes');
 
 // Cargamos las variables de entorno desde el archivo .env
@@ -38,6 +39,7 @@ mongoose.connect(MONGO_URI)
 app.use('/api/pacientes', pacientesRoutes);
 app.use('/api/obras-sociales', obrasSocialesRoutes);
 app.use('/api/facturas', facturasRoutes);
+app.use('/api/turnos', turnosRoutes);
 app.use('/api/users', userRoutes);
 
 // Es un endpoint. Para las peticiones al servidor, las realice. 

--- a/backend/models/Turno.js
+++ b/backend/models/Turno.js
@@ -1,0 +1,55 @@
+const mongoose = require('mongoose');
+
+const turnoSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    paciente: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Paciente',
+      required: true,
+    },
+    titulo: {
+      type: String,
+      trim: true,
+    },
+    notas: {
+      type: String,
+      trim: true,
+    },
+    fecha: {
+      type: Date,
+      required: true,
+    },
+    duracionMinutos: {
+      type: Number,
+      default: 30,
+      min: 5,
+    },
+    estado: {
+      type: String,
+      enum: ['programado', 'completado', 'cancelado'],
+      default: 'programado',
+    },
+    recordatorioHorasAntes: {
+      type: Number,
+      min: 0,
+    },
+    recordatorioProgramadoPara: {
+      type: Date,
+    },
+    recordatorioEnviado: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  { timestamps: true }
+);
+
+turnoSchema.index({ user: 1, fecha: 1 });
+
+module.exports = mongoose.model('Turno', turnoSchema);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import PacientesPage from './pages/PacientesPage';
 import ObrasSocialesPage from './pages/ObrasSocialesPage';
 import FacturasPage from './pages/FacturasPage';
 import DashboardPage from './pages/DashboardPage';
+import TurnosPage from './pages/TurnosPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import GestioLogo from './assets/GestioLogo.png';
@@ -68,6 +69,9 @@ function App() {
                     <NavLink className="nav-link" to="/pacientes" onClick={closeMenu}>Pacientes</NavLink>
                   </li>
                   <li className="nav-item">
+                    <NavLink className="nav-link" to="/turnos" onClick={closeMenu}>Agenda</NavLink>
+                  </li>
+                  <li className="nav-item">
                     <NavLink className="nav-link" to="/obras-sociales" onClick={closeMenu}>Obras Sociales</NavLink>
                   </li>
                   <li className="nav-item">
@@ -115,6 +119,7 @@ function App() {
             <>
               <Route path="/pacientes" element={<PacientesPage />} />
               <Route path="/obras-sociales" element={<ObrasSocialesPage />} />
+              <Route path="/turnos" element={<TurnosPage />} />
               <Route path="/facturas" element={<FacturasPage />} />
               <Route path="/dashboard" element={<DashboardPage />} />
               <Route path="/" element={<DashboardPage />} />

--- a/frontend/src/pages/TurnosPage.jsx
+++ b/frontend/src/pages/TurnosPage.jsx
@@ -1,0 +1,500 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import turnosService from '../services/TurnosService';
+import PacientesService from '../services/PacientesService';
+
+const formatoFechaLocal = (fechaISO) => {
+  if (!fechaISO) return '';
+  return new Date(fechaISO).toLocaleString('es-AR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+};
+
+const formatearFechaParaInput = (fechaISO) => {
+  if (!fechaISO) return '';
+  const fecha = new Date(fechaISO);
+  const offset = fecha.getTimezoneOffset();
+  const local = new Date(fecha.getTime() - offset * 60 * 1000);
+  return local.toISOString().slice(0, 16);
+};
+
+const calcularRango = (rango) => {
+  const ahora = new Date();
+  const inicio = new Date(ahora);
+  const fin = new Date(ahora);
+
+  if (rango === 'hoy') {
+    inicio.setHours(0, 0, 0, 0);
+    fin.setHours(23, 59, 59, 999);
+    return {
+      desde: inicio.toISOString(),
+      hasta: fin.toISOString(),
+    };
+  }
+
+  if (rango === 'semana') {
+    inicio.setHours(0, 0, 0, 0);
+    fin.setDate(fin.getDate() + 7);
+    return {
+      desde: inicio.toISOString(),
+      hasta: fin.toISOString(),
+    };
+  }
+
+  return {};
+};
+
+const estadoBadgeClass = {
+  programado: 'bg-primary',
+  completado: 'bg-success',
+  cancelado: 'bg-secondary',
+};
+
+const estadoLabel = {
+  programado: 'Programado',
+  completado: 'Completado',
+  cancelado: 'Cancelado',
+};
+
+const TurnosPage = () => {
+  const [turnos, setTurnos] = useState([]);
+  const [pacientes, setPacientes] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+  const [formData, setFormData] = useState({
+    paciente: '',
+    titulo: '',
+    fecha: '',
+    duracionMinutos: 30,
+    estado: 'programado',
+    notas: '',
+    recordatorioHorasAntes: 24,
+  });
+  const [filtros, setFiltros] = useState({ estado: 'programado', rango: 'semana' });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const obtenerDatos = async () => {
+      const [listaPacientes] = await Promise.all([
+        PacientesService.getPacientes(),
+      ]);
+      setPacientes(listaPacientes);
+    };
+    obtenerDatos();
+  }, []);
+
+  useEffect(() => {
+    const cargarTurnos = async () => {
+      try {
+        setLoading(true);
+        const rango = calcularRango(filtros.rango);
+        const parametros = {
+          ...rango,
+        };
+        if (filtros.estado !== 'todos') {
+          parametros.estado = filtros.estado;
+        }
+        const data = await turnosService.getTurnos(parametros);
+        setTurnos(data);
+      } catch (error) {
+        console.error('No se pudieron obtener los turnos', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    cargarTurnos();
+  }, [filtros]);
+
+  const proximosTurnos = useMemo(() => {
+    const ahora = new Date().getTime();
+    return turnos.filter((turno) => new Date(turno.fecha).getTime() >= ahora);
+  }, [turnos]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const resetForm = () => {
+    setFormData({
+      paciente: '',
+      titulo: '',
+      fecha: '',
+      duracionMinutos: 30,
+      estado: 'programado',
+      notas: '',
+      recordatorioHorasAntes: 24,
+    });
+    setEditingId(null);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!formData.paciente || !formData.fecha) {
+      return;
+    }
+
+    const payload = {
+      paciente: formData.paciente,
+      titulo: formData.titulo,
+      fecha: formData.fecha ? new Date(formData.fecha).toISOString() : null,
+      duracionMinutos: Number(formData.duracionMinutos) || 30,
+      estado: formData.estado,
+      notas: formData.notas,
+      recordatorioHorasAntes:
+        formData.recordatorioHorasAntes === ''
+          ? null
+          : Number(formData.recordatorioHorasAntes),
+    };
+
+    try {
+      setLoading(true);
+      if (editingId) {
+        await turnosService.updateTurno(editingId, payload);
+      } else {
+        await turnosService.createTurno(payload);
+      }
+      resetForm();
+      const rango = calcularRango(filtros.rango);
+      const parametros = filtros.estado !== 'todos' ? { estado: filtros.estado, ...rango } : { ...rango };
+      const data = await turnosService.getTurnos(parametros);
+      setTurnos(data);
+    } catch (error) {
+      console.error('No se pudo guardar el turno', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (turno) => {
+    setEditingId(turno._id);
+    setFormData({
+      paciente: turno.paciente?._id || '',
+      titulo: turno.titulo || '',
+      fecha: formatearFechaParaInput(turno.fecha),
+      duracionMinutos: turno.duracionMinutos || 30,
+      estado: turno.estado || 'programado',
+      notas: turno.notas || '',
+      recordatorioHorasAntes:
+        turno.recordatorioHorasAntes === undefined || turno.recordatorioHorasAntes === null
+          ? ''
+          : turno.recordatorioHorasAntes,
+    });
+  };
+
+  const handleDelete = async (id) => {
+    try {
+      setLoading(true);
+      await turnosService.deleteTurno(id);
+      setTurnos((prev) => prev.filter((turno) => turno._id !== id));
+      if (editingId === id) {
+        resetForm();
+      }
+    } catch (error) {
+      console.error('No se pudo eliminar el turno', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleRecordatorio = async (turno) => {
+    try {
+      setLoading(true);
+      const actualizado = await turnosService.updateRecordatorio(turno._id, !turno.recordatorioEnviado);
+      setTurnos((prev) => prev.map((item) => (item._id === actualizado._id ? actualizado : item)));
+    } catch (error) {
+      console.error('No se pudo actualizar el recordatorio', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFiltroChange = (event) => {
+    const { name, value } = event.target;
+    setFiltros((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <div className="container mt-4">
+      <div className="card shadow-sm mb-4">
+        <div className="card-header bg-primary text-white d-flex flex-column flex-md-row align-items-md-center justify-content-md-between">
+          <h2 className="mb-2 mb-md-0">Agenda de turnos</h2>
+          <div className="d-flex gap-2">
+            <select
+              name="estado"
+              className="form-select"
+              value={filtros.estado}
+              onChange={handleFiltroChange}
+            >
+              <option value="todos">Todos los estados</option>
+              <option value="programado">Programados</option>
+              <option value="completado">Completados</option>
+              <option value="cancelado">Cancelados</option>
+            </select>
+            <select name="rango" className="form-select" value={filtros.rango} onChange={handleFiltroChange}>
+              <option value="todos">Todo el historial</option>
+              <option value="hoy">Solo hoy</option>
+              <option value="semana">Próximos 7 días</option>
+            </select>
+          </div>
+        </div>
+        <div className="card-body">
+          <form onSubmit={handleSubmit}>
+            <div className="row g-3">
+              <div className="col-md-6 col-lg-4">
+                <label className="form-label">Paciente</label>
+                <select
+                  name="paciente"
+                  className="form-select"
+                  value={formData.paciente}
+                  onChange={handleChange}
+                  required
+                >
+                  <option value="">Seleccione un paciente</option>
+                  {pacientes.map((paciente) => (
+                    <option key={paciente._id} value={paciente._id}>
+                      {paciente.nombre} {paciente.apellido}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-md-6 col-lg-4">
+                <label className="form-label">Fecha y hora</label>
+                <input
+                  type="datetime-local"
+                  name="fecha"
+                  className="form-control"
+                  value={formData.fecha}
+                  onChange={handleChange}
+                  required
+                />
+              </div>
+              <div className="col-md-6 col-lg-2">
+                <label className="form-label">Duración (min)</label>
+                <input
+                  type="number"
+                  min="5"
+                  name="duracionMinutos"
+                  className="form-control"
+                  value={formData.duracionMinutos}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="col-md-6 col-lg-2">
+                <label className="form-label">Estado</label>
+                <select
+                  name="estado"
+                  className="form-select"
+                  value={formData.estado}
+                  onChange={handleChange}
+                >
+                  <option value="programado">Programado</option>
+                  <option value="completado">Completado</option>
+                  <option value="cancelado">Cancelado</option>
+                </select>
+              </div>
+              <div className="col-md-6 col-lg-4">
+                <label className="form-label">Título del turno</label>
+                <input
+                  type="text"
+                  name="titulo"
+                  className="form-control"
+                  placeholder="Control, primera visita..."
+                  value={formData.titulo}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="col-md-6 col-lg-4">
+                <label className="form-label">Recordatorio (horas antes)</label>
+                <input
+                  type="number"
+                  min="0"
+                  name="recordatorioHorasAntes"
+                  className="form-control"
+                  value={formData.recordatorioHorasAntes}
+                  onChange={handleChange}
+                  placeholder="24"
+                />
+              </div>
+              <div className="col-12">
+                <label className="form-label">Notas</label>
+                <textarea
+                  name="notas"
+                  className="form-control"
+                  rows="2"
+                  value={formData.notas}
+                  onChange={handleChange}
+                  placeholder="Detalles clínicos, indicaciones o recordatorios internos"
+                ></textarea>
+              </div>
+              <div className="col-12 d-flex justify-content-end gap-2">
+                {editingId && (
+                  <button type="button" className="btn btn-secondary" onClick={resetForm}>
+                    Cancelar edición
+                  </button>
+                )}
+                <button type="submit" className="btn btn-primary" disabled={loading}>
+                  {editingId ? 'Actualizar turno' : 'Crear turno'}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div className="card shadow-sm d-none d-md-block">
+        <div className="card-body">
+          {loading && <p>Cargando...</p>}
+          {!loading && turnos.length === 0 && <p className="mb-0">No hay turnos para los filtros seleccionados.</p>}
+          {!loading && turnos.length > 0 && (
+            <table className="table table-hover align-middle">
+              <thead className="table-light">
+                <tr>
+                  <th>Paciente</th>
+                  <th>Fecha</th>
+                  <th>Duración</th>
+                  <th>Estado</th>
+                  <th>Recordatorio</th>
+                  <th>Notas</th>
+                  <th className="text-end">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {turnos.map((turno) => (
+                  <tr key={turno._id}>
+                    <td>
+                      <strong>{turno.paciente?.nombre} {turno.paciente?.apellido}</strong>
+                      <div className="text-muted small">{turno.titulo || 'Sin título'}</div>
+                    </td>
+                    <td>{formatoFechaLocal(turno.fecha)}</td>
+                    <td>{turno.duracionMinutos} min</td>
+                    <td>
+                      <span className={`badge ${estadoBadgeClass[turno.estado] || 'bg-secondary'}`}>
+                        {estadoLabel[turno.estado] || turno.estado}
+                      </span>
+                    </td>
+                    <td>
+                      <div className="d-flex flex-column">
+                        {turno.recordatorioProgramadoPara ? (
+                          <span className="small text-muted">
+                            Programado: {formatoFechaLocal(turno.recordatorioProgramadoPara)}
+                          </span>
+                        ) : (
+                          <span className="small text-muted">Sin recordatorio programado</span>
+                        )}
+                        <button
+                          type="button"
+                          className={`btn btn-sm mt-1 ${turno.recordatorioEnviado ? 'btn-success' : 'btn-outline-primary'}`}
+                          onClick={() => toggleRecordatorio(turno)}
+                        >
+                          {turno.recordatorioEnviado ? 'Recordatorio enviado' : 'Marcar como enviado'}
+                        </button>
+                      </div>
+                    </td>
+                    <td className="small">{turno.notas || '—'}</td>
+                    <td className="text-end">
+                      <div className="btn-group" role="group">
+                        <button className="btn btn-warning btn-sm" onClick={() => handleEdit(turno)}>
+                          Editar
+                        </button>
+                        <button className="btn btn-danger btn-sm" onClick={() => handleDelete(turno._id)}>
+                          Eliminar
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <div className="d-md-none">
+        {loading && <p>Cargando...</p>}
+        {!loading && turnos.length === 0 && <p>No hay turnos para mostrar.</p>}
+        <div className="row g-3">
+          {turnos.map((turno) => (
+            <div className="col-12" key={turno._id}>
+              <div className="card shadow-sm">
+                <div className="card-body">
+                  <div className="d-flex justify-content-between align-items-start">
+                    <div>
+                      <h5 className="card-title mb-1">
+                        {turno.paciente?.nombre} {turno.paciente?.apellido}
+                      </h5>
+                      <p className="text-muted mb-2">{turno.titulo || 'Sin título'}</p>
+                    </div>
+                    <span className={`badge ${estadoBadgeClass[turno.estado] || 'bg-secondary'}`}>
+                      {estadoLabel[turno.estado] || turno.estado}
+                    </span>
+                  </div>
+                  <p className="mb-1">
+                    <strong>Fecha:</strong> {formatoFechaLocal(turno.fecha)}
+                  </p>
+                  <p className="mb-1">
+                    <strong>Duración:</strong> {turno.duracionMinutos} min
+                  </p>
+                  <p className="mb-1">
+                    <strong>Recordatorio:</strong>{' '}
+                    {turno.recordatorioProgramadoPara
+                      ? formatoFechaLocal(turno.recordatorioProgramadoPara)
+                      : 'No programado'}
+                  </p>
+                  {turno.notas && (
+                    <p className="mb-2">
+                      <strong>Notas:</strong> {turno.notas}
+                    </p>
+                  )}
+                  <div className="d-flex flex-wrap gap-2">
+                    <button className="btn btn-warning btn-sm" onClick={() => handleEdit(turno)}>
+                      Editar
+                    </button>
+                    <button className="btn btn-danger btn-sm" onClick={() => handleDelete(turno._id)}>
+                      Eliminar
+                    </button>
+                    <button
+                      className={`btn btn-sm ${turno.recordatorioEnviado ? 'btn-success' : 'btn-outline-primary'}`}
+                      onClick={() => toggleRecordatorio(turno)}
+                    >
+                      {turno.recordatorioEnviado ? 'Recordatorio enviado' : 'Marcar recordatorio'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="card shadow-sm mt-4">
+        <div className="card-body">
+          <h5 className="card-title">Turnos futuros</h5>
+          {proximosTurnos.length === 0 ? (
+            <p className="mb-0">No hay turnos próximos agendados.</p>
+          ) : (
+            <ul className="list-group list-group-flush">
+              {proximosTurnos.slice(0, 5).map((turno) => (
+                <li className="list-group-item d-flex justify-content-between align-items-center" key={turno._id}>
+                  <div>
+                    <strong>{turno.paciente?.nombre} {turno.paciente?.apellido}</strong>
+                    <div className="text-muted small">{turno.titulo || 'Sin título'}</div>
+                  </div>
+                  <span>{formatoFechaLocal(turno.fecha)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TurnosPage;

--- a/frontend/src/services/TurnosService.js
+++ b/frontend/src/services/TurnosService.js
@@ -1,0 +1,87 @@
+import axios from 'axios';
+import authService from './authService';
+
+const API_URL = `${import.meta.env.VITE_APP_API_URL}/turnos`;
+
+const getHeaders = () => {
+  const token = authService.getToken();
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+};
+
+const buildQueryString = (params = {}) => {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      query.append(key, value);
+    }
+  });
+  const queryString = query.toString();
+  return queryString ? `?${queryString}` : '';
+};
+
+const getTurnos = async (params = {}) => {
+  try {
+    const response = await axios.get(`${API_URL}${buildQueryString(params)}`, getHeaders());
+    return response.data;
+  } catch (error) {
+    console.error('Error al obtener turnos:', error);
+    throw error;
+  }
+};
+
+const createTurno = async (turnoData) => {
+  try {
+    const response = await axios.post(API_URL, turnoData, getHeaders());
+    return response.data;
+  } catch (error) {
+    console.error('Error al crear turno:', error);
+    throw error;
+  }
+};
+
+const updateTurno = async (id, turnoData) => {
+  try {
+    const response = await axios.put(`${API_URL}/${id}`, turnoData, getHeaders());
+    return response.data;
+  } catch (error) {
+    console.error('Error al actualizar turno:', error);
+    throw error;
+  }
+};
+
+const deleteTurno = async (id) => {
+  try {
+    await axios.delete(`${API_URL}/${id}`, getHeaders());
+  } catch (error) {
+    console.error('Error al eliminar turno:', error);
+    throw error;
+  }
+};
+
+const updateRecordatorio = async (id, estado) => {
+  try {
+    const response = await axios.patch(
+      `${API_URL}/${id}/recordatorio`,
+      { recordatorioEnviado: estado },
+      getHeaders()
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error al actualizar recordatorio:', error);
+    throw error;
+  }
+};
+
+const turnosService = {
+  getTurnos,
+  createTurno,
+  updateTurno,
+  deleteTurno,
+  updateRecordatorio,
+};
+
+export default turnosService;


### PR DESCRIPTION
## Summary
- create a Turno model plus protected routes to manage appointments and reminder states
- expose a React agenda view with filters, CRUD actions, and reminder toggles linked to patients
- hook the navigation and client service layer into the new appointments API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e48bfd23088330bdfd1d1d68a86eb6