### PR TITLE
Add health center management and patient contact enhancements

### DIFF
--- a/backend/Routes/centrosSalud.js
+++ b/backend/Routes/centrosSalud.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router();
+const CentroSalud = require('../models/CentroSalud');
+const { protect } = require('../middleware/authMiddleware');
+
+// Crear un centro de salud
+router.post('/', protect, async (req, res) => {
+  try {
+    const { nombre, porcentajeRetencion } = req.body;
+
+    const centro = new CentroSalud({
+      nombre,
+      porcentajeRetencion,
+      user: req.user._id,
+    });
+
+    await centro.save();
+    res.status(201).json(centro);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+// Obtener todos los centros de salud del usuario
+router.get('/', protect, async (req, res) => {
+  try {
+    const centros = await CentroSalud.find({ user: req.user._id }).sort({ createdAt: -1 });
+    res.json(centros);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Actualizar un centro de salud
+router.put('/:id', protect, async (req, res) => {
+  try {
+    const { nombre, porcentajeRetencion } = req.body;
+
+    const centroActualizado = await CentroSalud.findOneAndUpdate(
+      { _id: req.params.id, user: req.user._id },
+      { nombre, porcentajeRetencion },
+      { new: true, runValidators: true }
+    );
+
+    if (!centroActualizado) {
+      return res.status(404).json({ error: 'Centro de salud no encontrado o no autorizado' });
+    }
+
+    res.json(centroActualizado);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+// Eliminar un centro de salud
+router.delete('/:id', protect, async (req, res) => {
+  try {
+    const eliminado = await CentroSalud.findOneAndDelete({ _id: req.params.id, user: req.user._id });
+    if (!eliminado) {
+      return res.status(404).json({ error: 'Centro de salud no encontrado o no autorizado' });
+    }
+
+    res.json({ message: 'Centro de salud eliminado correctamente' });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,6 +9,7 @@ const obrasSocialesRoutes = require('./Routes/obrasSociales');
 const facturasRoutes = require('./Routes/facturas');
 const turnosRoutes = require('./Routes/turnos');
 const userRoutes = require('./Routes/userRoutes');
+const centrosSaludRoutes = require('./Routes/centrosSalud');
 
 // Cargamos las variables de entorno desde el archivo .env
 dotenv.config();
@@ -38,6 +39,7 @@ mongoose.connect(MONGO_URI)
 // Usamos las rutas para cada modelo
 app.use('/api/pacientes', pacientesRoutes);
 app.use('/api/obras-sociales', obrasSocialesRoutes);
+app.use('/api/centros-salud', centrosSaludRoutes);
 app.use('/api/facturas', facturasRoutes);
 app.use('/api/turnos', turnosRoutes);
 app.use('/api/users', userRoutes);

--- a/backend/models/CentroSalud.js
+++ b/backend/models/CentroSalud.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const centroSaludSchema = new mongoose.Schema({
+  nombre: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  porcentajeRetencion: {
+    type: Number,
+    required: true,
+    min: 0,
+    max: 100,
+  },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true,
+  },
+}, { timestamps: true });
+
+module.exports = mongoose.model('CentroSalud', centroSaludSchema);

--- a/backend/models/Factura.js
+++ b/backend/models/Factura.js
@@ -5,6 +5,7 @@ const ESTADOS_FACTURA = ['pendiente', 'presentada', 'observada', 'pagada_parcial
 const facturaSchema = new mongoose.Schema({
   paciente: { type: mongoose.Schema.Types.ObjectId, ref: 'Paciente', required: true },
   obraSocial: { type: mongoose.Schema.Types.ObjectId, ref: 'ObraSocial' },
+  centroSalud: { type: mongoose.Schema.Types.ObjectId, ref: 'CentroSalud' },
   numeroFactura: { type: Number, required: true, unique: true },
   montoTotal: { type: Number, required: true, min: 0 },
   fechaEmision: { type: Date, required: true },

--- a/backend/models/Paciente.js
+++ b/backend/models/Paciente.js
@@ -3,13 +3,28 @@ const mongoose = require('mongoose');
 const pacienteSchema = new mongoose.Schema({
   nombre: { type: String, required: true },
   apellido: { type: String, required: true },
-  dni: { type: String, required: true, unique: true },
+  dni: { type: String, required: true, trim: true },
+  email: { type: String, trim: true, lowercase: true },
+  telefono: { type: String, trim: true },
+  tipoAtencion: { type: String, enum: ['particular', 'centro'], default: 'particular' },
+  centroSalud: { type: mongoose.Schema.Types.ObjectId, ref: 'CentroSalud' },
   obraSocial: { type: mongoose.Schema.Types.ObjectId, ref: 'ObraSocial' },
-  user: { // Nuevo campo
+  user: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
     required: true,
   }
-}, { timestamps: true });
+}, {
+  timestamps: true,
+});
+
+pacienteSchema.pre('validate', function validateCentro(next) {
+  if (this.tipoAtencion === 'centro' && !this.centroSalud) {
+    return next(new Error('Debes seleccionar un centro de salud para pacientes atendidos por centro.'));
+  }
+  return next();
+});
+
+pacienteSchema.index({ user: 1, dni: 1 }, { unique: true });
 
 module.exports = mongoose.model('Paciente', pacienteSchema);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import ObrasSocialesPage from './pages/ObrasSocialesPage';
 import FacturasPage from './pages/FacturasPage';
 import DashboardPage from './pages/DashboardPage';
 import TurnosPage from './pages/TurnosPage';
+import CentrosSaludPage from './pages/CentrosSaludPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import CompleteProfilePage from './pages/CompleteProfilePage';
@@ -84,6 +85,9 @@ function App() {
                 <>
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/pacientes" onClick={closeMenu}>Pacientes</NavLink>
+                  </li>
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/centros-salud" onClick={closeMenu}>Centros de Salud</NavLink>
                   </li>
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/turnos" onClick={closeMenu}>Agenda</NavLink>
@@ -175,6 +179,7 @@ function App() {
               <Route path="/pacientes" element={<PacientesPage />} />
               <Route path="/obras-sociales" element={<ObrasSocialesPage />} />
               <Route path="/turnos" element={<TurnosPage />} />
+              <Route path="/centros-salud" element={<CentrosSaludPage />} />
               <Route path="/facturas" element={<FacturasPage />} />
               <Route path="/dashboard" element={<DashboardPage currentUser={currentUser} />} />
               <Route path="/" element={<DashboardPage currentUser={currentUser} />} />

--- a/frontend/src/pages/CentrosSaludPage.jsx
+++ b/frontend/src/pages/CentrosSaludPage.jsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import centrosSaludService from '../services/CentrosSaludService';
+import facturasService from '../services/FacturasService';
+
+const EMPTY_FORM = {
+  nombre: '',
+  porcentajeRetencion: '',
+};
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(Number(value) || 0);
+};
+
+function CentrosSaludPage() {
+  const [centros, setCentros] = useState([]);
+  const [facturas, setFacturas] = useState([]);
+  const [formData, setFormData] = useState(EMPTY_FORM);
+  const [editingId, setEditingId] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchCentros();
+    fetchFacturas();
+  }, []);
+
+  const fetchCentros = async () => {
+    try {
+      const data = await centrosSaludService.getCentros();
+      setCentros(data);
+    } catch (err) {
+      console.error('Error al obtener centros de salud:', err);
+    }
+  };
+
+  const fetchFacturas = async () => {
+    try {
+      const data = await facturasService.getFacturas();
+      setFacturas(data);
+    } catch (err) {
+      console.error('Error al obtener facturas:', err);
+    }
+  };
+
+  const resumenCentros = useMemo(() => {
+    const acumulado = centros.reduce((acc, centro) => {
+      acc[centro._id] = {
+        centro,
+        totalFacturado: 0,
+        totalRetencion: 0,
+        cantidadFacturas: 0,
+      };
+      return acc;
+    }, {});
+
+    facturas.forEach((factura) => {
+      const centroId = factura.centroSalud?._id || factura.centroSalud;
+      if (centroId && acumulado[centroId]) {
+        const porcentaje = acumulado[centroId].centro.porcentajeRetencion || 0;
+        acumulado[centroId].totalFacturado += factura.montoTotal || 0;
+        acumulado[centroId].totalRetencion += (factura.montoTotal || 0) * (porcentaje / 100);
+        acumulado[centroId].cantidadFacturas += 1;
+      }
+    });
+
+    return Object.values(acumulado).sort((a, b) => b.totalRetencion - a.totalRetencion);
+  }, [centros, facturas]);
+
+  const totalRetencion = useMemo(() => {
+    return resumenCentros.reduce((sum, item) => sum + item.totalRetencion, 0);
+  }, [resumenCentros]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const resetForm = () => {
+    setFormData(EMPTY_FORM);
+    setEditingId(null);
+    setError(null);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+
+    const porcentaje = Number(formData.porcentajeRetencion);
+    if (!Number.isFinite(porcentaje) || porcentaje < 0 || porcentaje > 100) {
+      setError('El porcentaje de retención debe estar entre 0% y 100%.');
+      return;
+    }
+
+    const payload = {
+      nombre: formData.nombre.trim(),
+      porcentajeRetencion: porcentaje,
+    };
+
+    if (!payload.nombre) {
+      setError('El nombre del centro es obligatorio.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      if (editingId) {
+        await centrosSaludService.updateCentro(editingId, payload);
+      } else {
+        await centrosSaludService.createCentro(payload);
+      }
+      resetForm();
+      fetchCentros();
+    } catch (err) {
+      const message = err.response?.data?.error || 'No se pudo guardar el centro de salud.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (centro) => {
+    setEditingId(centro._id);
+    setFormData({
+      nombre: centro.nombre,
+      porcentajeRetencion: centro.porcentajeRetencion,
+    });
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('¿Deseas eliminar este centro de salud? Esta acción no se puede deshacer.')) {
+      return;
+    }
+    try {
+      setLoading(true);
+      await centrosSaludService.deleteCentro(id);
+      if (editingId === id) {
+        resetForm();
+      }
+      fetchCentros();
+    } catch (err) {
+      console.error('Error al eliminar centro de salud:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container py-4">
+      <div className="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+        <div>
+          <h2 className="fw-bold mb-1">Red de Centros de Salud</h2>
+          <p className="text-muted mb-0">Administra los convenios vigentes y controla las retenciones asociadas.</p>
+        </div>
+        <div className="text-lg-end mt-3 mt-lg-0">
+          <h5 className="text-primary mb-1">Retención acumulada</h5>
+          <h3 className="fw-bold">{formatCurrency(totalRetencion)}</h3>
+        </div>
+      </div>
+
+      <div className="card shadow-sm mb-4">
+        <div className="card-header bg-primary text-white">
+          {editingId ? 'Editar centro de salud' : 'Agregar centro de salud'}
+        </div>
+        <div className="card-body">
+          {error && <div className="alert alert-danger">{error}</div>}
+          <form className="row g-3 align-items-end" onSubmit={handleSubmit}>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="nombreCentro">Nombre del centro</label>
+              <input
+                id="nombreCentro"
+                type="text"
+                name="nombre"
+                className="form-control"
+                value={formData.nombre}
+                onChange={handleChange}
+                placeholder="Ej. Centro Médico Norte"
+                required
+              />
+            </div>
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="retencionCentro">Retención (%)</label>
+              <input
+                id="retencionCentro"
+                type="number"
+                name="porcentajeRetencion"
+                className="form-control"
+                min="0"
+                max="100"
+                step="0.1"
+                value={formData.porcentajeRetencion}
+                onChange={handleChange}
+                placeholder="Ej. 20"
+                required
+              />
+            </div>
+            <div className="col-md-2 d-flex gap-2">
+              {editingId && (
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary flex-fill"
+                  onClick={resetForm}
+                  disabled={loading}
+                >
+                  Cancelar
+                </button>
+              )}
+              <button type="submit" className="btn btn-primary flex-fill" disabled={loading}>
+                {editingId ? 'Actualizar' : 'Guardar'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div className="card shadow-sm">
+        <div className="card-header bg-light">
+          <strong>Centros registrados</strong>
+        </div>
+        <div className="card-body p-0">
+          {centros.length === 0 ? (
+            <p className="text-center text-muted py-4 mb-0">Todavía no registraste centros de salud.</p>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th>Centro</th>
+                    <th className="text-center">Retención</th>
+                    <th className="text-end">Facturación vinculada</th>
+                    <th className="text-end">Retención a pagar</th>
+                    <th className="text-center">Facturas</th>
+                    <th className="text-end">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resumenCentros.map(({ centro, totalFacturado, totalRetencion, cantidadFacturas }) => (
+                    <tr key={centro._id}>
+                      <td>
+                        <div className="fw-semibold">{centro.nombre}</div>
+                        <small className="text-muted">Actualizado el {new Date(centro.updatedAt).toLocaleDateString()}</small>
+                      </td>
+                      <td className="text-center">{centro.porcentajeRetencion}%</td>
+                      <td className="text-end">{formatCurrency(totalFacturado)}</td>
+                      <td className="text-end fw-bold text-primary">{formatCurrency(totalRetencion)}</td>
+                      <td className="text-center">{cantidadFacturas}</td>
+                      <td className="text-end">
+                        <div className="btn-group btn-group-sm" role="group">
+                          <button className="btn btn-outline-secondary" onClick={() => handleEdit(centro)} disabled={loading}>
+                            Editar
+                          </button>
+                          <button className="btn btn-outline-danger" onClick={() => handleDelete(centro._id)} disabled={loading}>
+                            Eliminar
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CentrosSaludPage;

--- a/frontend/src/services/CentrosSaludService.js
+++ b/frontend/src/services/CentrosSaludService.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import authService from './authService';
+
+const API_URL = `${import.meta.env.VITE_APP_API_URL}/centros-salud`;
+
+const getHeaders = () => {
+  const token = authService.getToken();
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+};
+
+const getCentros = async () => {
+  const response = await axios.get(API_URL, getHeaders());
+  return response.data;
+};
+
+const createCentro = async (data) => {
+  const response = await axios.post(API_URL, data, getHeaders());
+  return response.data;
+};
+
+const updateCentro = async (id, data) => {
+  const response = await axios.put(`${API_URL}/${id}`, data, getHeaders());
+  return response.data;
+};
+
+const deleteCentro = async (id) => {
+  await axios.delete(`${API_URL}/${id}`, getHeaders());
+};
+
+export default {
+  getCentros,
+  createCentro,
+  updateCentro,
+  deleteCentro,
+};


### PR DESCRIPTION
## Summary
- add a CentroSalud model and API to manage health centers per profesional
- extend pacientes and facturas endpoints to store patient contact data and link invoices to centers when applicable
- expose new UI for health centers, enrich patient and facturas workflows, and refresh the dashboard with executive and retention metrics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5df73634c83309673a9fdb5bdb3fb