### PR TITLE
Add financial breakdown to dashboard and capture CUIT for obras sociales

### DIFF
--- a/backend/models/ObraSocial.js
+++ b/backend/models/ObraSocial.js
@@ -4,6 +4,7 @@ const obraSocialSchema = new mongoose.Schema({
   nombre: { type: String, required: true },
   telefono: { type: String },
   email: { type: String },
+  cuit: { type: String, trim: true },
   user: { // Nuevo campo
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,8 @@ import ProfilePage from './pages/ProfilePage';
 import GestioLogo from './assets/GestioLogo.png';
 import authService from './services/authService';
 
+const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'v1.0.0';
+
 function App() {
   const [currentUser, setCurrentUser] = useState(() => {
     const storedUser = localStorage.getItem('user');
@@ -61,7 +63,7 @@ function App() {
       <nav className="navbar navbar-expand-lg navbar-dark bg-dark">
         <div className="container">
           {/* Nombre de la aplicación y logo */}
-          <NavLink className="navbar-brand d-flex align-items-center" to="/dashboard" onClick={closeMenu}>
+          <NavLink className="navbar-brand d-flex align-items-center" to="/" onClick={closeMenu}>
             <img src={GestioLogo} alt="Gestio Logo" style={{ height: '40px', marginRight: '10px' }} />
             <span style={{ fontFamily: 'Barlow, sans-serif' }}>GESTIO</span>
           </NavLink>
@@ -97,9 +99,6 @@ function App() {
                   </li>
                   <li className="nav-item">
                     <NavLink className="nav-link" to="/facturas" onClick={closeMenu}>Facturación</NavLink>
-                  </li>
-                  <li className="nav-item">
-                    <NavLink className="nav-link" to="/dashboard" onClick={closeMenu}>Dashboard</NavLink>
                   </li>
                 </>
               )}
@@ -142,9 +141,11 @@ function App() {
 
   return (
     <BrowserRouter>
-      <NavContent />
-      <div className="container mt-4">
-        <Routes>
+      <div className="d-flex flex-column min-vh-100">
+        <NavContent />
+        <main className="flex-grow-1">
+          <div className="container mt-4">
+            <Routes>
           {!isAuthenticated && (
             <>
               <Route path="/login" element={<LoginPage onAuthChange={handleAuthChange} />} />
@@ -186,7 +187,15 @@ function App() {
               <Route path="*" element={<DashboardPage currentUser={currentUser} />} />
             </>
           )}
-        </Routes>
+            </Routes>
+          </div>
+        </main>
+        <footer className="bg-dark text-white py-3 mt-auto">
+          <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
+            <span>© {new Date().getFullYear()} Gestio. Todos los derechos reservados.</span>
+            <span>Versión {APP_VERSION}</span>
+          </div>
+        </footer>
       </div>
     </BrowserRouter>
   );

--- a/frontend/src/pages/ObrasSocialesPage.jsx
+++ b/frontend/src/pages/ObrasSocialesPage.jsx
@@ -7,6 +7,7 @@ function ObrasSocialesPage() {
     nombre: '',
     telefono: '',
     email: '',
+    cuit: '',
   });
   const [editingId, setEditingId] = useState(null);
 
@@ -31,7 +32,7 @@ function ObrasSocialesPage() {
     } else {
       await ObrasSocialesService.createObraSocial(formData);
     }
-    setFormData({ nombre: '', telefono: '', email: '' });
+    setFormData({ nombre: '', telefono: '', email: '', cuit: '' });
     fetchObrasSociales();
   };
 
@@ -46,6 +47,7 @@ function ObrasSocialesPage() {
       nombre: os.nombre,
       telefono: os.telefono,
       email: os.email,
+      cuit: os.cuit || '',
     });
   };
 
@@ -55,6 +57,7 @@ function ObrasSocialesPage() {
       nombre: '',
       telefono: '',
       email: '',
+      cuit: '',
     });
   };
 
@@ -76,6 +79,16 @@ function ObrasSocialesPage() {
                   value={formData.nombre}
                   onChange={handleChange}
                   required
+                />
+              </div>
+              <div className="col-md-4">
+                <input
+                  type="text"
+                  name="cuit"
+                  className="form-control"
+                  placeholder="CUIT/CUIL"
+                  value={formData.cuit}
+                  onChange={handleChange}
                 />
               </div>
               <div className="col-md-4">
@@ -120,6 +133,7 @@ function ObrasSocialesPage() {
             <thead className="table-dark">
               <tr>
                 <th>Nombre</th>
+                <th>CUIT/CUIL</th>
                 <th>Teléfono</th>
                 <th>Email</th>
                 <th>Acciones</th>
@@ -129,6 +143,7 @@ function ObrasSocialesPage() {
               {obrasSociales.map((os) => (
                 <tr key={os._id}>
                   <td>{os.nombre}</td>
+                  <td>{os.cuit || '—'}</td>
                   <td>{os.telefono}</td>
                   <td>{os.email}</td>
                   <td>
@@ -160,6 +175,7 @@ function ObrasSocialesPage() {
               <div className="card shadow-sm">
                 <div className="card-body">
                   <h5 className="card-title">{os.nombre}</h5>
+                  <p className="card-text mb-1"><strong>CUIT/CUIL:</strong> {os.cuit || '—'}</p>
                   <p className="card-text mb-1"><strong>Teléfono:</strong> {os.telefono}</p>
                   <p className="card-text"><strong>Email:</strong> {os.email}</p>
                   <div className="d-flex justify-content-between mt-3">


### PR DESCRIPTION
## Summary
- extend the dashboard financial summary with net amounts for private and centre-based patients plus total retention
- remove the dashboard link from the navigation, route the logo/home to the dashboard, and add an application footer with the version
- store and display CUIT/CUIL information for obras sociales records in the API and UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5eb7a3f2c83309f7bde46d4c0dc0e