### PR TITLE
Add inactivity logout and improve user feedback across modules

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { BrowserRouter, Routes, Route, NavLink, useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Routes, Route, NavLink } from 'react-router-dom';
 import PacientesPage from './pages/PacientesPage';
 import ObrasSocialesPage from './pages/ObrasSocialesPage';
 import FacturasPage from './pages/FacturasPage';
@@ -12,15 +12,21 @@ import CompleteProfilePage from './pages/CompleteProfilePage';
 import ProfilePage from './pages/ProfilePage';
 import GestioLogo from './assets/GestioLogo.png';
 import authService from './services/authService';
+import { useFeedback } from './context/FeedbackContext.jsx';
+import { useNavigate } from 'react-router-dom';
 
 const APP_VERSION = import.meta.env.VITE_APP_VERSION || 'v1.0.0';
+const INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutos
 
 function App() {
+  const navigate = useNavigate();
+  const { showInfo, showSuccess } = useFeedback();
   const [currentUser, setCurrentUser] = useState(() => {
     const storedUser = localStorage.getItem('user');
     return storedUser ? JSON.parse(storedUser) : null;
   });
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const inactivityTimerRef = useRef(null);
 
   useEffect(() => {
     const storedUser = localStorage.getItem('user');
@@ -29,9 +35,7 @@ function App() {
     }
   }, []);
 
-  const isAuthenticated = Boolean(currentUser?.token);
-
-  const handleAuthChange = (userData) => {
+  const handleAuthChange = useCallback((userData) => {
     if (userData) {
       localStorage.setItem('user', JSON.stringify(userData));
       setCurrentUser(userData);
@@ -39,22 +43,68 @@ function App() {
       localStorage.removeItem('user');
       setCurrentUser(null);
     }
-  };
+  }, []);
 
-  const handleLogout = () => {
-    authService.logout();
-    handleAuthChange(null);
-  };
+  const handleLogout = useCallback(
+    ({ reason } = {}) => {
+      authService.logout();
+      handleAuthChange(null);
 
-  const NavContent = () => {
-    const navigate = useNavigate();
-    const onLogout = () => {
-      setIsMenuOpen(false);
-      handleLogout();
+      if (reason === 'timeout') {
+        showInfo('Por seguridad, tu sesión se cerró tras 20 minutos sin actividad. Inicia sesión nuevamente para continuar.');
+      } else {
+        showSuccess('Sesión cerrada correctamente. ¡Hasta pronto!');
+      }
+
       navigate('/login');
+    },
+    [handleAuthChange, navigate, showInfo, showSuccess],
+  );
+
+  const isAuthenticated = Boolean(currentUser?.token);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+      return undefined;
+    }
+
+    const resetTimer = () => {
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+      inactivityTimerRef.current = window.setTimeout(() => {
+        handleLogout({ reason: 'timeout' });
+      }, INACTIVITY_TIMEOUT_MS);
     };
 
-    // Función para cerrar el menú en dispositivos móviles
+    const activityEvents = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'];
+    activityEvents.forEach((event) => document.addEventListener(event, resetTimer));
+
+    resetTimer();
+
+    return () => {
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+      activityEvents.forEach((event) => document.removeEventListener(event, resetTimer));
+    };
+  }, [handleLogout, isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setIsMenuOpen(false);
+    }
+  }, [isAuthenticated]);
+
+  const NavContent = () => {
+    const onLogoutClick = () => {
+      setIsMenuOpen(false);
+      handleLogout();
+    };
+
     const closeMenu = () => {
       setIsMenuOpen(false);
     };
@@ -62,43 +112,50 @@ function App() {
     return (
       <nav className="navbar navbar-expand-lg navbar-dark bg-dark">
         <div className="container">
-          {/* Nombre de la aplicación y logo */}
           <NavLink className="navbar-brand d-flex align-items-center" to="/" onClick={closeMenu}>
             <img src={GestioLogo} alt="Gestio Logo" style={{ height: '40px', marginRight: '10px' }} />
             <span style={{ fontFamily: 'Barlow, sans-serif' }}>GESTIO</span>
           </NavLink>
-          
-          {/* Botón del menú hamburguesa, ahora controlado por el estado de React */}
-          <button 
-            className="navbar-toggler" 
-            type="button" 
+
+          <button
+            className="navbar-toggler"
+            type="button"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
-            aria-controls="navbarNav" 
-            aria-expanded={isMenuOpen} 
+            aria-controls="navbarNav"
+            aria-expanded={isMenuOpen}
             aria-label="Toggle navigation"
           >
             <span className="navbar-toggler-icon"></span>
           </button>
-          
-          {/* Contenido del menú colapsable, ahora controlado por el estado de React */}
+
           <div className={`collapse navbar-collapse ${isMenuOpen ? 'show' : ''}`} id="navbarNav">
             <ul className="navbar-nav me-auto">
               {isAuthenticated && (
                 <>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/pacientes" onClick={closeMenu}>Pacientes</NavLink>
+                    <NavLink className="nav-link" to="/pacientes" onClick={closeMenu}>
+                      Pacientes
+                    </NavLink>
                   </li>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/centros-salud" onClick={closeMenu}>Centros de Salud</NavLink>
+                    <NavLink className="nav-link" to="/centros-salud" onClick={closeMenu}>
+                      Centros de Salud
+                    </NavLink>
                   </li>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/turnos" onClick={closeMenu}>Agenda</NavLink>
+                    <NavLink className="nav-link" to="/turnos" onClick={closeMenu}>
+                      Agenda
+                    </NavLink>
                   </li>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/obras-sociales" onClick={closeMenu}>Obras Sociales</NavLink>
+                    <NavLink className="nav-link" to="/obras-sociales" onClick={closeMenu}>
+                      Obras Sociales
+                    </NavLink>
                   </li>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/facturas" onClick={closeMenu}>Facturación</NavLink>
+                    <NavLink className="nav-link" to="/facturas" onClick={closeMenu}>
+                      Facturación
+                    </NavLink>
                   </li>
                 </>
               )}
@@ -114,10 +171,12 @@ function App() {
                     </li>
                   )}
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/profile" onClick={closeMenu}>Perfil</NavLink>
+                    <NavLink className="nav-link" to="/profile" onClick={closeMenu}>
+                      Perfil
+                    </NavLink>
                   </li>
                   <li className="nav-item ms-lg-3 mt-2 mt-lg-0">
-                    <button onClick={onLogout} className="btn btn-outline-light w-100">
+                    <button onClick={onLogoutClick} className="btn btn-outline-light w-100">
                       Cerrar Sesión
                     </button>
                   </li>
@@ -125,10 +184,14 @@ function App() {
               ) : (
                 <>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/login" onClick={closeMenu}>Iniciar Sesión</NavLink>
+                    <NavLink className="nav-link" to="/login" onClick={closeMenu}>
+                      Iniciar Sesión
+                    </NavLink>
                   </li>
                   <li className="nav-item">
-                    <NavLink className="nav-link" to="/register" onClick={closeMenu}>Registrarse</NavLink>
+                    <NavLink className="nav-link" to="/register" onClick={closeMenu}>
+                      Registrarse
+                    </NavLink>
                   </li>
                 </>
               )}
@@ -140,64 +203,59 @@ function App() {
   };
 
   return (
-    <BrowserRouter>
-      <div className="d-flex flex-column min-vh-100">
-        <NavContent />
-        <main className="flex-grow-1">
-          <div className="container mt-4">
-            <Routes>
-          {!isAuthenticated && (
-            <>
-              <Route path="/login" element={<LoginPage onAuthChange={handleAuthChange} />} />
-              <Route path="/register" element={<RegisterPage onAuthChange={handleAuthChange} />} />
-              <Route path="*" element={<LoginPage onAuthChange={handleAuthChange} />} />
-            </>
-          )}
+    <div className="d-flex flex-column min-vh-100">
+      <NavContent />
+      <main className="flex-grow-1">
+        <div className="container mt-4">
+          <Routes>
+            {!isAuthenticated && (
+              <>
+                <Route path="/login" element={<LoginPage onAuthChange={handleAuthChange} />} />
+                <Route path="/register" element={<RegisterPage onAuthChange={handleAuthChange} />} />
+                <Route path="*" element={<LoginPage onAuthChange={handleAuthChange} />} />
+              </>
+            )}
 
-          {isAuthenticated && !currentUser.profileCompleted && (
-            <>
-              <Route
-                path="/complete-profile"
-                element={<CompleteProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
-              />
-              <Route
-                path="*"
-                element={<CompleteProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
-              />
-            </>
-          )}
+            {isAuthenticated && !currentUser.profileCompleted && (
+              <>
+                <Route
+                  path="/complete-profile"
+                  element={<CompleteProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
+                />
+                <Route
+                  path="*"
+                  element={<CompleteProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
+                />
+              </>
+            )}
 
-          {isAuthenticated && currentUser.profileCompleted && (
-            <>
-              <Route
-                path="/complete-profile"
-                element={<CompleteProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
-              />
-              <Route
-                path="/profile"
-                element={<ProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
-              />
-              <Route path="/pacientes" element={<PacientesPage />} />
-              <Route path="/obras-sociales" element={<ObrasSocialesPage />} />
-              <Route path="/turnos" element={<TurnosPage />} />
-              <Route path="/centros-salud" element={<CentrosSaludPage />} />
-              <Route path="/facturas" element={<FacturasPage />} />
-              <Route path="/dashboard" element={<DashboardPage currentUser={currentUser} />} />
-              <Route path="/" element={<DashboardPage currentUser={currentUser} />} />
-              <Route path="*" element={<DashboardPage currentUser={currentUser} />} />
-            </>
-          )}
-            </Routes>
-          </div>
-        </main>
-        <footer className="bg-dark text-white py-3 mt-auto">
-          <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
-            <span>© {new Date().getFullYear()} Gestio. Todos los derechos reservados.</span>
-            <span>Versión {APP_VERSION}</span>
-          </div>
-        </footer>
-      </div>
-    </BrowserRouter>
+            {isAuthenticated && currentUser.profileCompleted && (
+              <>
+                <Route
+                  path="/complete-profile"
+                  element={<CompleteProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />}
+                />
+                <Route path="/profile" element={<ProfilePage currentUser={currentUser} onProfileUpdated={handleAuthChange} />} />
+                <Route path="/pacientes" element={<PacientesPage />} />
+                <Route path="/obras-sociales" element={<ObrasSocialesPage />} />
+                <Route path="/turnos" element={<TurnosPage />} />
+                <Route path="/centros-salud" element={<CentrosSaludPage />} />
+                <Route path="/facturas" element={<FacturasPage />} />
+                <Route path="/dashboard" element={<DashboardPage currentUser={currentUser} />} />
+                <Route path="/" element={<DashboardPage currentUser={currentUser} />} />
+                <Route path="*" element={<DashboardPage currentUser={currentUser} />} />
+              </>
+            )}
+          </Routes>
+        </div>
+      </main>
+      <footer className="bg-dark text-white py-3 mt-auto">
+        <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
+          <span>© {new Date().getFullYear()} Gestio. Todos los derechos reservados.</span>
+          <span>Versión {APP_VERSION}</span>
+        </div>
+      </footer>
+    </div>
   );
 }
 

--- a/frontend/src/context/FeedbackContext.jsx
+++ b/frontend/src/context/FeedbackContext.jsx
@@ -1,0 +1,80 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+const FeedbackContext = createContext(null);
+
+const TYPE_TO_CLASS = {
+  success: 'success',
+  error: 'danger',
+  warning: 'warning',
+  info: 'info',
+};
+
+export const FeedbackProvider = ({ children }) => {
+  const [messages, setMessages] = useState([]);
+
+  const removeMessage = useCallback((id) => {
+    setMessages((prev) => prev.filter((message) => message.id !== id));
+  }, []);
+
+  const showMessage = useCallback(
+    ({ type = 'info', text, duration = 5000 } = {}) => {
+      if (!text) {
+        return;
+      }
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      setMessages((prev) => [...prev, { id, type, text }]);
+
+      if (duration) {
+        window.setTimeout(() => {
+          removeMessage(id);
+        }, duration);
+      }
+    },
+    [removeMessage],
+  );
+
+  const helpers = useMemo(
+    () => ({
+      showMessage,
+      showSuccess: (text, duration) => showMessage({ type: 'success', text, duration }),
+      showError: (text, duration) => showMessage({ type: 'error', text, duration }),
+      showWarning: (text, duration) => showMessage({ type: 'warning', text, duration }),
+      showInfo: (text, duration) => showMessage({ type: 'info', text, duration }),
+      dismiss: removeMessage,
+    }),
+    [removeMessage, showMessage],
+  );
+
+  return (
+    <FeedbackContext.Provider value={helpers}>
+      {children}
+      <div className="position-fixed top-0 end-0 p-3" style={{ zIndex: 1100, minWidth: '280px' }}>
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={`alert alert-${TYPE_TO_CLASS[message.type] || 'info'} shadow d-flex align-items-start justify-content-between gap-3 mb-2`}
+            role="alert"
+          >
+            <div className="flex-grow-1">{message.text}</div>
+            <button
+              type="button"
+              className="btn-close"
+              aria-label="Cerrar"
+              onClick={() => removeMessage(message.id)}
+            ></button>
+          </div>
+        ))}
+      </div>
+    </FeedbackContext.Provider>
+  );
+};
+
+export const useFeedback = () => {
+  const context = useContext(FeedbackContext);
+  if (!context) {
+    throw new Error('useFeedback debe utilizarse dentro de un FeedbackProvider');
+  }
+  return context;
+};
+
+export default FeedbackContext;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,12 +1,17 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.jsx'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import { FeedbackProvider } from './context/FeedbackContext.jsx';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap/dist/js/bootstrap.bundle.min.js'; // <-- ¡Esta es la línea que faltaba!
-
+import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <FeedbackProvider>
+        <App />
+      </FeedbackProvider>
+    </BrowserRouter>
   </React.StrictMode>,
-)
+);

--- a/frontend/src/pages/CentrosSaludPage.jsx
+++ b/frontend/src/pages/CentrosSaludPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import centrosSaludService from '../services/CentrosSaludService';
 import facturasService from '../services/FacturasService';
+import { useFeedback } from '../context/FeedbackContext.jsx';
 
 const EMPTY_FORM = {
   nombre: '',
@@ -12,6 +13,7 @@ const formatCurrency = (value) => {
 };
 
 function CentrosSaludPage() {
+  const { showError, showSuccess, showInfo } = useFeedback();
   const [centros, setCentros] = useState([]);
   const [facturas, setFacturas] = useState([]);
   const [formData, setFormData] = useState(EMPTY_FORM);
@@ -29,7 +31,7 @@ function CentrosSaludPage() {
       const data = await centrosSaludService.getCentros();
       setCentros(data);
     } catch (err) {
-      console.error('Error al obtener centros de salud:', err);
+      showError('No se pudieron cargar los centros de salud.');
     }
   };
 
@@ -38,7 +40,7 @@ function CentrosSaludPage() {
       const data = await facturasService.getFacturas();
       setFacturas(data);
     } catch (err) {
-      console.error('Error al obtener facturas:', err);
+      showError('No se pudo obtener la facturación vinculada a los centros.');
     }
   };
 
@@ -103,16 +105,19 @@ function CentrosSaludPage() {
 
     try {
       setLoading(true);
-      if (editingId) {
+      const isEditing = Boolean(editingId);
+      if (isEditing) {
         await centrosSaludService.updateCentro(editingId, payload);
       } else {
         await centrosSaludService.createCentro(payload);
       }
       resetForm();
       fetchCentros();
+      showSuccess(isEditing ? 'Centro de salud actualizado correctamente.' : 'Centro de salud creado correctamente.');
     } catch (err) {
       const message = err.response?.data?.error || 'No se pudo guardar el centro de salud.';
       setError(message);
+      showError(message);
     } finally {
       setLoading(false);
     }
@@ -137,8 +142,9 @@ function CentrosSaludPage() {
         resetForm();
       }
       fetchCentros();
+      showInfo('El centro de salud se eliminó correctamente.');
     } catch (err) {
-      console.error('Error al eliminar centro de salud:', err);
+      showError('No se pudo eliminar el centro de salud.');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/ObrasSocialesPage.jsx
+++ b/frontend/src/pages/ObrasSocialesPage.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import ObrasSocialesService from '../services/ObrasSocialesService';
+import { useFeedback } from '../context/FeedbackContext.jsx';
 
 function ObrasSocialesPage() {
+  const { showError, showSuccess, showInfo } = useFeedback();
   const [obrasSociales, setObrasSociales] = useState([]);
   const [formData, setFormData] = useState({
     nombre: '',
@@ -10,15 +12,25 @@ function ObrasSocialesPage() {
     cuit: '',
   });
   const [editingId, setEditingId] = useState(null);
+  const [listLoading, setListLoading] = useState(false);
+  const [formLoading, setFormLoading] = useState(false);
+  const [deleteLoadingId, setDeleteLoadingId] = useState(null);
+
+  const fetchObrasSociales = useCallback(async () => {
+    try {
+      setListLoading(true);
+      const data = await ObrasSocialesService.getObrasSociales();
+      setObrasSociales(data);
+    } catch (error) {
+      showError('No se pudieron cargar las obras sociales.');
+    } finally {
+      setListLoading(false);
+    }
+  }, [showError]);
 
   useEffect(() => {
     fetchObrasSociales();
-  }, []);
-
-  const fetchObrasSociales = async () => {
-    const data = await ObrasSocialesService.getObrasSociales();
-    setObrasSociales(data);
-  };
+  }, [fetchObrasSociales]);
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -26,19 +38,44 @@ function ObrasSocialesPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (editingId) {
-      await ObrasSocialesService.updateObraSocial(editingId, formData);
-      setEditingId(null);
-    } else {
-      await ObrasSocialesService.createObraSocial(formData);
+    try {
+      setFormLoading(true);
+      if (editingId) {
+        await ObrasSocialesService.updateObraSocial(editingId, formData);
+        showSuccess('Obra social actualizada correctamente.');
+        setEditingId(null);
+      } else {
+        await ObrasSocialesService.createObraSocial(formData);
+        showSuccess('Obra social creada correctamente.');
+      }
+      setFormData({ nombre: '', telefono: '', email: '', cuit: '' });
+      await fetchObrasSociales();
+    } catch (error) {
+      const message = error.response?.data?.message || 'No se pudo guardar la obra social. Intenta nuevamente.';
+      showError(message);
+    } finally {
+      setFormLoading(false);
     }
-    setFormData({ nombre: '', telefono: '', email: '', cuit: '' });
-    fetchObrasSociales();
   };
 
   const handleDelete = async (id) => {
-    await ObrasSocialesService.deleteObraSocial(id);
-    fetchObrasSociales();
+    if (!window.confirm('¿Deseas eliminar esta obra social?')) {
+      return;
+    }
+    try {
+      setDeleteLoadingId(id);
+      await ObrasSocialesService.deleteObraSocial(id);
+      await fetchObrasSociales();
+      showInfo('La obra social se eliminó correctamente.');
+      if (editingId === id) {
+        handleCancelEdit();
+      }
+    } catch (error) {
+      const message = error.response?.data?.message || 'No se pudo eliminar la obra social.';
+      showError(message);
+    } finally {
+      setDeleteLoadingId(null);
+    }
   };
 
   const handleEdit = (os) => {
@@ -69,7 +106,8 @@ function ObrasSocialesPage() {
         </div>
         <div className="card-body">
           <form onSubmit={handleSubmit}>
-            <div className="row g-3">
+            <fieldset disabled={formLoading} className="border-0 p-0">
+              <div className="row g-3">
               <div className="col-md-4">
                 <input
                   type="text"
@@ -111,17 +149,29 @@ function ObrasSocialesPage() {
                   onChange={handleChange}
                 />
               </div>
-              <div className="col-12 mt-3 d-flex justify-content-end">
-                {editingId && (
-                  <button type="button" className="btn btn-secondary me-2" onClick={handleCancelEdit}>
-                    Cancelar
+                <div className="col-12 mt-3 d-flex justify-content-end">
+                  {editingId && (
+                    <button type="button" className="btn btn-secondary me-2" onClick={handleCancelEdit}>
+                      Cancelar
+                    </button>
+                  )}
+                  <button type="submit" className="btn btn-info text-white" disabled={formLoading}>
+                    {formLoading ? (
+                      <>
+                        <span
+                          className="spinner-border spinner-border-sm me-2"
+                          role="status"
+                          aria-hidden="true"
+                        ></span>
+                        {editingId ? 'Actualizando...' : 'Agregando...'}
+                      </>
+                    ) : (
+                      <>{editingId ? 'Actualizar Obra Social' : 'Agregar Obra Social'}</>
+                    )}
                   </button>
-                )}
-                <button type="submit" className="btn btn-info text-white">
-                  {editingId ? 'Actualizar Obra Social' : 'Agregar Obra Social'}
-                </button>
+                </div>
               </div>
-            </div>
+            </fieldset>
           </form>
         </div>
       </div>
@@ -140,28 +190,58 @@ function ObrasSocialesPage() {
               </tr>
             </thead>
             <tbody>
-              {obrasSociales.map((os) => (
-                <tr key={os._id}>
-                  <td>{os.nombre}</td>
-                  <td>{os.cuit || '—'}</td>
-                  <td>{os.telefono}</td>
-                  <td>{os.email}</td>
-                  <td>
-                    <button
-                      className="btn btn-warning btn-sm me-2"
-                      onClick={() => handleEdit(os)}
-                    >
-                      Editar
-                    </button>
-                    <button
-                      className="btn btn-danger btn-sm"
-                      onClick={() => handleDelete(os._id)}
-                    >
-                      Eliminar
-                    </button>
+              {listLoading ? (
+                <tr>
+                  <td colSpan="5" className="text-center py-4">
+                    <div className="d-inline-flex align-items-center gap-2">
+                      <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                      <span>Cargando obras sociales...</span>
+                    </div>
                   </td>
                 </tr>
-              ))}
+              ) : obrasSociales.length === 0 ? (
+                <tr>
+                  <td colSpan="5" className="text-center text-muted py-4">
+                    No hay obras sociales registradas.
+                  </td>
+                </tr>
+              ) : (
+                obrasSociales.map((os) => (
+                  <tr key={os._id}>
+                    <td>{os.nombre}</td>
+                    <td>{os.cuit || '—'}</td>
+                    <td>{os.telefono}</td>
+                    <td>{os.email}</td>
+                    <td>
+                      <button
+                        className="btn btn-warning btn-sm me-2"
+                        onClick={() => handleEdit(os)}
+                        disabled={formLoading || Boolean(deleteLoadingId)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        className="btn btn-danger btn-sm"
+                        onClick={() => handleDelete(os._id)}
+                        disabled={deleteLoadingId === os._id || formLoading}
+                      >
+                        {deleteLoadingId === os._id ? (
+                          <>
+                            <span
+                              className="spinner-border spinner-border-sm me-2"
+                              role="status"
+                              aria-hidden="true"
+                            ></span>
+                            Eliminando...
+                          </>
+                        ) : (
+                          'Eliminar'
+                        )}
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>
@@ -170,7 +250,21 @@ function ObrasSocialesPage() {
       {/* Cards para dispositivos pequeños (móvil) */}
       <div className="d-md-none">
         <div className="row g-3">
-          {obrasSociales.map((os) => (
+          {listLoading && (
+            <div className="col-12">
+              <div className="d-flex justify-content-center align-items-center py-4">
+                <span className="spinner-border text-info" role="status" aria-hidden="true"></span>
+                <span className="ms-2">Cargando obras sociales...</span>
+              </div>
+            </div>
+          )}
+          {!listLoading && obrasSociales.length === 0 && (
+            <div className="col-12">
+              <div className="alert alert-light text-center mb-0">Todavía no registraste obras sociales.</div>
+            </div>
+          )}
+          {!listLoading &&
+            obrasSociales.map((os) => (
             <div className="col-12" key={os._id}>
               <div className="card shadow-sm">
                 <div className="card-body">
@@ -182,20 +276,33 @@ function ObrasSocialesPage() {
                     <button
                       className="btn btn-warning btn-sm me-2"
                       onClick={() => handleEdit(os)}
+                      disabled={formLoading || Boolean(deleteLoadingId)}
                     >
                       Editar
                     </button>
                     <button
                       className="btn btn-danger btn-sm"
                       onClick={() => handleDelete(os._id)}
+                      disabled={deleteLoadingId === os._id || formLoading}
                     >
-                      Eliminar
+                      {deleteLoadingId === os._id ? (
+                        <>
+                          <span
+                            className="spinner-border spinner-border-sm me-2"
+                            role="status"
+                            aria-hidden="true"
+                          ></span>
+                          Eliminando...
+                        </>
+                      ) : (
+                        'Eliminar'
+                      )}
                     </button>
                   </div>
                 </div>
               </div>
             </div>
-          ))}
+            ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce a global feedback provider to surface success and error toasts across the application
- enforce an automatic logout after 20 minutes of inactivity and centralize router handling inside the main entrypoint
- harden patient, turnos, obras sociales, facturación y centros de salud flows with loading states, confirmations, and error notifications

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e65dac62bc8330b3fbf62d6f37cbc2