### PR TITLE
Fix AI assistant timezone output and navbar label

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,5 @@
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Routes, Route, NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { FaRobot } from 'react-icons/fa';
 import GestioLogo from './assets/GestioLogo.png';
 import Navbar from './components/Navbar.jsx';
 import authService from './services/authService';
@@ -119,7 +118,6 @@ const NAVIGATION_ITEMS = [
     to: '/asistente-ia',
     label: 'Asistente IA',
     ariaLabel: 'Consultar con el asistente virtual',
-    icon: FaRobot,
   },
 ];
 


### PR DESCRIPTION
## Summary
- format assistant snapshot dates with the configured application timezone and human-readable output
- update the assistant system prompt to avoid table responses and favor list formatting
- show the "Asistente IA" text in the navigation bar instead of the chatbot icon

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f268fe87b08330891b9bc652e15998