### PR TITLE
Add request performance monitoring middleware

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -117,6 +117,22 @@ if (process.env.NODE_ENV === 'test') {
     res.json(requestMetrics.getSnapshot());
   });
 
+  testRouter.get('/delayed', (req, res) => {
+    const delayParam = Number.parseInt(req.query.delayMs, 10);
+    const delayMs = Number.isFinite(delayParam) ? Math.min(Math.max(delayParam, 0), 10000) : 500;
+
+    const timer = setTimeout(() => {
+      if (res.writableEnded || res.headersSent || res.destroyed) {
+        return;
+      }
+      res.json({ delayMs });
+    }, delayMs);
+
+    res.on('close', () => {
+      clearTimeout(timer);
+    });
+  });
+
   app.use('/__test__', testRouter);
 }
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -8,6 +8,8 @@ const { protect } = require('./middleware/authMiddleware');
 const securityHeaders = require('./middleware/securityHeaders');
 const sanitizeRequest = require('./middleware/sanitizeRequest');
 const rateLimiter = require('./middleware/rateLimiter');
+const performanceMonitor = require('./middleware/performanceMonitor');
+const requestMetrics = require('./utils/requestMetrics');
 
 const pacientesRoutes = require('./Routes/pacientes');
 const obrasSocialesRoutes = require('./Routes/obrasSociales');
@@ -22,6 +24,10 @@ dotenv.config();
 const app = express();
 
 app.disable('x-powered-by');
+
+app.locals.requestMetrics = requestMetrics;
+
+app.use(performanceMonitor);
 
 const resolveAllowedOrigins = () => {
   const envValue = process.env.ALLOWED_ORIGINS;
@@ -105,6 +111,10 @@ if (process.env.NODE_ENV === 'test') {
 
   testRouter.get('/protected', protect, (req, res) => {
     res.json({ message: 'ok' });
+  });
+
+  testRouter.get('/metrics', (req, res) => {
+    res.json(requestMetrics.getSnapshot());
   });
 
   app.use('/__test__', testRouter);

--- a/backend/middleware/performanceMonitor.js
+++ b/backend/middleware/performanceMonitor.js
@@ -1,0 +1,23 @@
+const { randomUUID } = require('node:crypto');
+const requestMetrics = require('../utils/requestMetrics');
+
+const formatMs = (value) => Math.round(value * 10) / 10;
+
+module.exports = (req, res, next) => {
+  const context = requestMetrics.startRequest();
+  const requestId = randomUUID();
+
+  req.requestId = requestId;
+  res.setHeader('X-Request-Id', requestId);
+
+  res.on('finish', () => {
+    const durationMs = requestMetrics.finishRequest(context, res);
+
+    if (durationMs >= requestMetrics.slowRequestThresholdMs) {
+      const message = `Solicitud lenta ${req.method} ${req.originalUrl} - ${formatMs(durationMs)}ms status=${res.statusCode} requestId=${requestId}`;
+      console.warn(`[performance] ${message}`);
+    }
+  });
+
+  next();
+};

--- a/backend/middleware/performanceMonitor.js
+++ b/backend/middleware/performanceMonitor.js
@@ -19,5 +19,9 @@ module.exports = (req, res, next) => {
     }
   });
 
+  res.on('close', () => {
+    requestMetrics.abandonRequest(context);
+  });
+
   next();
 };

--- a/backend/tests/requestMetrics.test.js
+++ b/backend/tests/requestMetrics.test.js
@@ -1,0 +1,77 @@
+process.env.NODE_ENV = 'test';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+let app;
+let server;
+let baseUrl;
+
+const startServer = async () => {
+  ({ app } = require('../app'));
+
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      const { port } = server.address();
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+};
+
+const stopServer = async () => {
+  if (!server) {
+    return;
+  }
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+};
+
+const fetchJson = async (url) => {
+  const response = await fetch(url);
+  const data = await response.json();
+  return { response, data };
+};
+
+const getMetricsSnapshot = async () => {
+  const { response, data } = await fetchJson(`${baseUrl}/__test__/metrics`);
+  assert.equal(response.status, 200);
+  return data;
+};
+
+test.before(async () => {
+  await startServer();
+});
+
+test.after(async () => {
+  await stopServer();
+});
+
+test('tracks request metrics and exposes request identifiers', async () => {
+  const before = await getMetricsSnapshot();
+
+  const apiResponse = await fetch(`${baseUrl}/api/unknown`);
+  assert.notEqual(apiResponse.status, 500);
+  const requestId = apiResponse.headers.get('x-request-id');
+  assert.ok(requestId, 'response should include a request identifier');
+
+  const after = await getMetricsSnapshot();
+
+  assert.ok(
+    after.totalRequests >= before.totalRequests + 2,
+    'total requests should include API and metrics calls',
+  );
+
+  assert.ok(after.completedRequests >= before.completedRequests + 2);
+  assert.ok(after.activeRequests <= 1, 'only the metrics request should remain active');
+  assert.ok(after.peakActiveRequests >= 1);
+
+  const before4xx = before.statusCounts?.['4xx'] ?? 0;
+  const after4xx = after.statusCounts?.['4xx'] ?? 0;
+  assert.ok(after4xx >= before4xx + 1, '404 request should be tracked');
+
+  if (after.completedRequests > 0) {
+    assert.ok(after.averageResponseTimeMs >= 0);
+  }
+});

--- a/backend/tests/requestMetrics.test.js
+++ b/backend/tests/requestMetrics.test.js
@@ -28,6 +28,11 @@ const stopServer = async () => {
   });
 };
 
+const sleep = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 const fetchJson = async (url) => {
   const response = await fetch(url);
   const data = await response.json();
@@ -74,4 +79,31 @@ test('tracks request metrics and exposes request identifiers', async () => {
   if (after.completedRequests > 0) {
     assert.ok(after.averageResponseTimeMs >= 0);
   }
+});
+
+test('aborted requests release active counts', async () => {
+  const before = await getMetricsSnapshot();
+
+  const controller = new AbortController();
+  const delayedRequest = fetch(`${baseUrl}/__test__/delayed?delayMs=200`, {
+    signal: controller.signal,
+  });
+
+  setTimeout(() => controller.abort(), 30);
+
+  await assert.rejects(delayedRequest, (error) => error?.name === 'AbortError');
+
+  await sleep(50);
+
+  const after = await getMetricsSnapshot();
+
+  assert.ok(
+    after.abortedRequests >= (before.abortedRequests ?? 0) + 1,
+    'aborted requests should be tracked',
+  );
+
+  assert.ok(
+    after.activeRequests <= 1,
+    'active request count should not remain inflated after an abort',
+  );
 });

--- a/backend/utils/requestMetrics.js
+++ b/backend/utils/requestMetrics.js
@@ -22,6 +22,7 @@ class RequestMetrics {
     this.slowRequests = 0;
     this.activeRequests = 0;
     this.peakActiveRequests = 0;
+    this.abortedRequests = 0;
     this.statusCounts = {
       '2xx': 0,
       '3xx': 0,
@@ -39,15 +40,17 @@ class RequestMetrics {
 
     return {
       startTime: performance.now(),
+      released: false,
     };
   }
 
   finishRequest(context, res) {
-    if (!context || typeof context.startTime !== 'number') {
+    if (!context || typeof context.startTime !== 'number' || context.released) {
       return 0;
     }
 
     const durationMs = performance.now() - context.startTime;
+    context.released = true;
     this.completedRequests += 1;
     this.totalResponseTimeMs += durationMs;
     this.longestRequestMs = Math.max(this.longestRequestMs, durationMs);
@@ -68,6 +71,16 @@ class RequestMetrics {
     return durationMs;
   }
 
+  abandonRequest(context) {
+    if (!context || context.released) {
+      return;
+    }
+
+    context.released = true;
+    this.activeRequests = Math.max(0, this.activeRequests - 1);
+    this.abortedRequests += 1;
+  }
+
   getSnapshot() {
     const averageResponseTimeMs =
       this.completedRequests === 0 ? 0 : this.totalResponseTimeMs / this.completedRequests;
@@ -82,6 +95,7 @@ class RequestMetrics {
       averageResponseTimeMs,
       longestRequestMs: this.longestRequestMs,
       slowRequests: this.slowRequests,
+      abortedRequests: this.abortedRequests,
       statusCounts: { ...this.statusCounts },
     };
   }

--- a/backend/utils/requestMetrics.js
+++ b/backend/utils/requestMetrics.js
@@ -1,0 +1,97 @@
+const { performance } = require('node:perf_hooks');
+
+const toPositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+class RequestMetrics {
+  constructor() {
+    this.slowRequestThresholdMs = toPositiveInteger(
+      process.env.SLOW_REQUEST_THRESHOLD_MS,
+      1200,
+    );
+    this.reset();
+  }
+
+  reset() {
+    this.totalRequests = 0;
+    this.completedRequests = 0;
+    this.totalResponseTimeMs = 0;
+    this.longestRequestMs = 0;
+    this.slowRequests = 0;
+    this.activeRequests = 0;
+    this.peakActiveRequests = 0;
+    this.statusCounts = {
+      '2xx': 0,
+      '3xx': 0,
+      '4xx': 0,
+      '5xx': 0,
+    };
+  }
+
+  startRequest() {
+    this.totalRequests += 1;
+    this.activeRequests += 1;
+    if (this.activeRequests > this.peakActiveRequests) {
+      this.peakActiveRequests = this.activeRequests;
+    }
+
+    return {
+      startTime: performance.now(),
+    };
+  }
+
+  finishRequest(context, res) {
+    if (!context || typeof context.startTime !== 'number') {
+      return 0;
+    }
+
+    const durationMs = performance.now() - context.startTime;
+    this.completedRequests += 1;
+    this.totalResponseTimeMs += durationMs;
+    this.longestRequestMs = Math.max(this.longestRequestMs, durationMs);
+
+    if (durationMs >= this.slowRequestThresholdMs) {
+      this.slowRequests += 1;
+    }
+
+    const statusCode = Number.parseInt(res.statusCode, 10);
+    const statusFamily = Number.isFinite(statusCode) ? `${Math.floor(statusCode / 100)}xx` : 'unknown';
+    if (!this.statusCounts[statusFamily]) {
+      this.statusCounts[statusFamily] = 0;
+    }
+    this.statusCounts[statusFamily] += 1;
+
+    this.activeRequests = Math.max(0, this.activeRequests - 1);
+
+    return durationMs;
+  }
+
+  getSnapshot() {
+    const averageResponseTimeMs =
+      this.completedRequests === 0 ? 0 : this.totalResponseTimeMs / this.completedRequests;
+
+    return {
+      timestamp: new Date().toISOString(),
+      slowRequestThresholdMs: this.slowRequestThresholdMs,
+      totalRequests: this.totalRequests,
+      completedRequests: this.completedRequests,
+      activeRequests: this.activeRequests,
+      peakActiveRequests: this.peakActiveRequests,
+      averageResponseTimeMs,
+      longestRequestMs: this.longestRequestMs,
+      slowRequests: this.slowRequests,
+      statusCounts: { ...this.statusCounts },
+    };
+  }
+
+  configure({ slowRequestThresholdMs } = {}) {
+    if (slowRequestThresholdMs) {
+      const parsed = toPositiveInteger(slowRequestThresholdMs, this.slowRequestThresholdMs);
+      this.slowRequestThresholdMs = parsed;
+    }
+  }
+}
+
+module.exports = new RequestMetrics();


### PR DESCRIPTION
## Summary
- add a performance monitoring middleware that assigns request identifiers, tracks latency, and warns on slow responses
- expose aggregated request metrics on the express app and through a test-only endpoint for observability
- add automated coverage that exercises the metrics pipeline and verifies headers

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691246faa694833099de04c9615f48c7)